### PR TITLE
resolve ambiguity for assertv_fresh

### DIFF
--- a/src/provers/ljt.lean
+++ b/src/provers/ljt.lean
@@ -1,5 +1,5 @@
 import .utils
-open tactic expr
+open tactic expr util
 
 /- the intuitionitsic prover -/
 
@@ -37,7 +37,7 @@ match t with
      | `(%%c ∧ %%d) :=
        do e ← mk_mapp ``uncurry [some c, some d, some b, pr],
           t ← to_expr ``(%%c → (%%d → %%b)),
-          assertv_fresh t e,
+          util.assertv_fresh t e,
           return tt
      | _ := return ff
      end

--- a/src/provers/utils.lean
+++ b/src/provers/utils.lean
@@ -82,7 +82,7 @@ def ljt_lemmas := [`imp_of_or_imp_left,
                    `absurd]
 
 /- some generally useful things -/
-
+namespace util
 def {u} list.first {α : Type u} (l : list α) (p : α → Prop) [decidable_pred p] : option α :=
 list.rec_on l none (λ h hs recval, if p h then some h else recval)
 
@@ -192,3 +192,4 @@ do h₁ ← nnf_at h,
 meta def nnf_hyps : tactic unit :=
 do hyps ← local_context,
 list.mmap nnf_at hyps >> return ()
+end util


### PR DESCRIPTION
I noticed an error associated with the fact that there are multiple implementations of assertv_fresh.  This PR gets the ljt prover to use the correct version.

```
Syntax::sntx: Invalid syntax in or before "
      /afs/inf.ed.ac.uk/user/j/jcorneli/bridge/_target/deps/mm_lean/src/provers/ljt.lean:40:10: error: ambiguous overload, possible interpretations"
       ^
     (line 1 of "/tmp/m000010362901").
```